### PR TITLE
Add GUSINFO team and product tag to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:MCI Next Backend Infra,MCI UI Infra


### PR DESCRIPTION
Assigns the GUS owning team and product tag for this repo in CODEOWNERS, per OSS compliance requirements.

Adds below `#ECCN:Open Source`:
```
#GUSINFO:MCI Next Backend Infra,MCI UI Infra
```

Both values verified against GUS — the product tag `MCI UI Infra` is owned by the `MCI Next Backend Infra` scrum team, which is the active team where MCI (f.k.a. Datorama) frontend-infra work is tracked.
- Team: https://gus.lightning.force.com/lightning/r/ADM_Scrum_Team__c/a00EE00000pRQHEYA4/view
- Product tag: https://gus.lightning.force.com/lightning/r/ADM_Product_Tag__c/a1aEE000000ly5ZYAQ/view