### PR TITLE
Add GUSINFO team and product tag to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:MCI Next Backend Infra,MCI UI Infra


### PR DESCRIPTION
Adds the GUS owning team and product tag to CODEOWNERS, per OSS compliance requirements.

Supersedes #37 (re-authored under external account to satisfy the CLA check).